### PR TITLE
Add visual merchandising planogram workbench

### DIFF
--- a/planogram.html
+++ b/planogram.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Atelier Planogram — Visual Merchandising</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;1,9..144,500&family=Outfit:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="planogram/css/app.css" />
+</head>
+<body>
+  <header class="app-header">
+    <div class="brand">
+      <em>Atelier Planogram</em>
+      <span>Visual merchandising workbench</span>
+    </div>
+    <nav class="tabs" aria-label="Primary">
+      <button type="button" id="tab-workspace" class="active">Planogram</button>
+      <button type="button" id="tab-audit">Compliance audit</button>
+    </nav>
+    <div class="header-actions">
+      <div class="capacity" title="Units placed versus fixture capacity">
+        <strong id="cap-label">0/40 items placed</strong>
+        <span class="bar"><i id="cap-bar"></i></span>
+      </div>
+      <button type="button" class="btn ghost" id="btn-clear">Clear fixture</button>
+      <button type="button" class="btn" id="btn-auto">Auto-Generate Planogram</button>
+      <button type="button" class="btn ghost" id="btn-export">Export Visual Work Order</button>
+    </div>
+  </header>
+
+  <section id="workspace" class="workspace visible">
+    <aside class="rail">
+      <h2>Fixture template</h2>
+      <div id="fixture-picks" class="fixture-picks"></div>
+      <div class="rules">
+        <p>Rules applied when you auto-generate</p>
+        <label><input type="checkbox" id="rule-color" checked /> Sort by color flow (light → dark luminance)</label>
+        <label><input type="checkbox" id="rule-cross" checked /> Cross-merchandising (matching bags on shelf / pegs)</label>
+        <label><input type="checkbox" id="rule-pair" checked /> Coordinate pairing (tops upper, bottoms lower)</label>
+      </div>
+      <h2>Catalog · 15 SKUs</h2>
+      <div id="catalog" class="catalog"></div>
+    </aside>
+    <div class="stage">
+      <p class="hint">Drag apparel onto snap points. Facings render as front cutouts, sideways hanger stacks, folded stacks with count badges, or mannequin silhouettes.</p>
+      <div class="canvas-wrap">
+        <svg id="fixture-svg" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Fixture planogram canvas"></svg>
+      </div>
+    </div>
+    <aside class="inspector">
+      <h2>Slot inspector</h2>
+      <div id="inspector-panel" class="panel"></div>
+    </aside>
+  </section>
+
+  <section id="audit" class="audit">
+    <div class="audit-grid">
+      <article class="audit-card">
+        <h3>Store display photo</h3>
+        <div class="photo-drop">
+          <p id="photo-hint" class="hint">Upload a mock floor photo to compare against the target planogram.</p>
+          <img id="photo-preview" alt="Uploaded store display" style="display:none" />
+          <input id="photo-input" type="file" accept="image/*" />
+        </div>
+      </article>
+      <article class="audit-card">
+        <h3>Target planogram</h3>
+        <svg id="audit-svg" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Target planogram"></svg>
+      </article>
+    </div>
+    <aside class="checklist">
+      <p class="hint">Mark each placed SKU Pass or Fail. Score uses marked items only.</p>
+      <p class="score" id="audit-score">0%</p>
+      <p class="hint" id="audit-score-meta">No SKUs scored yet</p>
+      <div id="audit-list"></div>
+    </aside>
+  </section>
+
+  <div id="print-root"></div>
+
+  <script src="planogram/js/catalog.js"></script>
+  <script src="planogram/js/fixtures.js"></script>
+  <script src="planogram/js/algorithm.js"></script>
+  <script src="planogram/js/app.js"></script>
+</body>
+</html>

--- a/planogram/css/app.css
+++ b/planogram/css/app.css
@@ -1,0 +1,424 @@
+:root {
+  --ink: #1c1917;
+  --ink-soft: #57534e;
+  --paper: #f4efe6;
+  --paper-2: #fffaf3;
+  --line: #d6cbb8;
+  --oxblood: #8f2d24;
+  --oxblood-dark: #6e2019;
+  --gold: #c4a574;
+  --sage: #4d6a4f;
+  --fail: #9f1239;
+  --pass: #166534;
+  --slot: rgba(28, 25, 23, 0.08);
+  --shadow: 0 18px 50px rgba(28, 25, 23, 0.12);
+  font-family: "Outfit", system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  min-height: 100%;
+  background:
+    radial-gradient(1200px 500px at 10% -10%, rgba(196, 165, 116, 0.18), transparent 50%),
+    var(--paper);
+  color: var(--ink);
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 16px 28px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(255, 250, 243, 0.86);
+  backdrop-filter: blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  min-width: 220px;
+}
+.brand em {
+  font-family: "Fraunces", Georgia, serif;
+  font-style: italic;
+  font-size: 1.35rem;
+  letter-spacing: -0.02em;
+}
+.brand span {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  background: #ece4d6;
+  padding: 4px;
+  border-radius: 999px;
+}
+.tabs button {
+  border: 0;
+  background: transparent;
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  color: var(--ink-soft);
+}
+.tabs button.active {
+  background: var(--ink);
+  color: var(--paper-2);
+}
+
+.header-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.capacity {
+  font-variant-numeric: tabular-nums;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 0.92rem;
+}
+.capacity strong { font-family: "Fraunces", serif; font-size: 1.05rem; }
+.capacity .bar {
+  display: inline-block;
+  width: 72px;
+  height: 6px;
+  background: #e7ddd0;
+  border-radius: 99px;
+  margin-left: 8px;
+  vertical-align: middle;
+  overflow: hidden;
+}
+.capacity .bar > i {
+  display: block;
+  height: 100%;
+  background: var(--oxblood);
+  width: 0%;
+}
+
+button.btn {
+  font: inherit;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--paper-2);
+  padding: 9px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+button.btn.ghost {
+  background: transparent;
+  color: var(--ink);
+}
+button.btn:hover { background: var(--oxblood-dark); color: #fff; border-color: var(--oxblood-dark); }
+button.btn.ghost:hover { background: #ece4d6; color: var(--ink); }
+
+.workspace, .audit {
+  display: none;
+  flex: 1;
+}
+.workspace.visible, .audit.visible { display: flex; }
+
+.workspace {
+  min-height: 0;
+}
+
+.rail {
+  width: 300px;
+  border-right: 1px solid var(--line);
+  background: var(--paper-2);
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 72px);
+}
+
+.rail h2, .inspector h2 {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin: 0;
+  padding: 16px 18px 8px;
+  color: var(--ink-soft);
+}
+
+.fixture-picks {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 14px 14px;
+}
+.fixture-picks button {
+  text-align: left;
+  border: 1px solid var(--line);
+  background: #fff;
+  border-radius: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  font: inherit;
+}
+.fixture-picks button.active {
+  border-color: var(--ink);
+  box-shadow: inset 0 0 0 1px var(--ink);
+}
+.fixture-picks small {
+  display: block;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+}
+
+.rules {
+  padding: 4px 18px 12px;
+  border-top: 1px solid var(--line);
+}
+.rules label {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  font-size: 0.88rem;
+  margin: 8px 0;
+  cursor: pointer;
+}
+.rules p {
+  margin: 0 0 8px;
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+}
+
+.catalog {
+  overflow: auto;
+  padding: 8px 12px 24px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  border-top: 1px solid var(--line);
+}
+
+.sku-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+  padding: 8px;
+  cursor: grab;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.sku-card:active { cursor: grabbing; }
+.sku-card img {
+  width: 100%;
+  height: 88px;
+  object-fit: contain;
+  background: #f7f1e8;
+  border-radius: 6px;
+}
+.sku-card .name { font-size: 0.78rem; font-weight: 600; line-height: 1.25; }
+.sku-card .meta {
+  font-size: 0.68rem;
+  color: var(--ink-soft);
+  display: flex;
+  justify-content: space-between;
+}
+.swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 99px;
+  border: 1px solid rgba(0,0,0,.2);
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.stage {
+  flex: 1;
+  padding: 18px 22px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.canvas-wrap {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 12px;
+  min-height: 540px;
+}
+.canvas-wrap svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  user-select: none;
+}
+
+.inspector {
+  width: 280px;
+  border-left: 1px solid var(--line);
+  background: var(--paper-2);
+  padding-bottom: 24px;
+}
+.inspector .panel { padding: 0 16px 12px; }
+.inspector .empty { color: var(--ink-soft); font-size: 0.9rem; }
+
+.qty-row { display: flex; align-items: center; gap: 8px; margin: 10px 0; }
+.qty-row button {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #fff;
+  cursor: pointer;
+  font: inherit;
+}
+
+select.facing {
+  width: 100%;
+  padding: 8px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  font: inherit;
+  background: #fff;
+}
+
+.audit {
+  padding: 20px 28px 40px;
+  gap: 20px;
+}
+.audit-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  flex: 1;
+}
+.audit-card {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px;
+  min-height: 320px;
+}
+.audit-card h3 {
+  font-family: "Fraunces", serif;
+  margin: 0 0 10px;
+}
+.photo-drop {
+  border: 1px dashed var(--gold);
+  border-radius: 10px;
+  min-height: 280px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #f7f1e8;
+  position: relative;
+}
+.photo-drop img { max-width: 100%; max-height: 420px; display: block; }
+.photo-drop input { position: absolute; inset: 0; opacity: 0; cursor: pointer; }
+
+.checklist {
+  width: 340px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px;
+  overflow: auto;
+}
+.score {
+  font-family: "Fraunces", serif;
+  font-size: 2.4rem;
+  margin: 0;
+}
+.check-row {
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.85rem;
+}
+.check-row img { width: 36px; height: 40px; object-fit: contain; }
+.seg {
+  display: flex;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.seg button {
+  border: 0;
+  background: #fff;
+  padding: 6px 8px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+}
+.seg button.on-pass { background: #dcfce7; color: var(--pass); }
+.seg button.on-fail { background: #ffe4e6; color: var(--fail); }
+
+#print-root { display: none; }
+
+@media print {
+  body * { visibility: hidden !important; }
+  #print-root, #print-root * { visibility: visible !important; }
+  #print-root {
+    display: block !important;
+    position: absolute;
+    inset: 0;
+    background: #fff;
+    color: #111;
+    padding: 24px;
+  }
+  .app-header, .workspace, .audit { display: none !important; }
+}
+
+.print-sheet h1 {
+  font-family: "Fraunces", Georgia, serif;
+  margin: 0 0 4px;
+}
+.print-sheet table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.print-sheet th, .print-sheet td {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 8px;
+  text-align: left;
+  vertical-align: middle;
+}
+.print-sheet img.thumb { width: 36px; height: 44px; object-fit: contain; }
+.print-visual svg { width: 100%; max-height: 420px; }
+
+.hint {
+  font-size: 0.8rem;
+  color: var(--ink-soft);
+  margin: 0;
+}
+
+@media (max-width: 1100px) {
+  .inspector { display: none; }
+  .audit-grid { grid-template-columns: 1fr; }
+  .checklist { width: 100%; }
+}

--- a/planogram/js/algorithm.js
+++ b/planogram/js/algorithm.js
@@ -1,0 +1,339 @@
+/**
+ * One-click auto-planogram rules:
+ *  a) Color flow — light → dark by relative luminance of colorHex
+ *  b) Cross-merchandising — matching accessories on shelf / side pegs
+ *  c) Coordinate pairing — tops on upper hanging, matching bottoms on lower
+ */
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.PlanogramAlgorithm = factory();
+  }
+})(typeof self !== "undefined" ? self : this, function () {
+  function hexLuminance(hex) {
+    var h = (hex || "#888888").replace("#", "");
+    if (h.length === 3) {
+      h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    }
+    var r = parseInt(h.slice(0, 2), 16) / 255;
+    var g = parseInt(h.slice(2, 4), 16) / 255;
+    var b = parseInt(h.slice(4, 6), 16) / 255;
+    function lin(c) {
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    }
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  }
+
+  function byLightToDark(a, b) {
+    return hexLuminance(b.colorHex) - hexLuminance(a.colorHex);
+  }
+
+  function clone(list) {
+    return list.slice();
+  }
+
+  function pickFacing(slot, product) {
+    var preferred = product.defaultFacing;
+    if (slot.allowedFacings.indexOf(preferred) !== -1) return preferred;
+    return slot.allowedFacings[0];
+  }
+
+  function matchingFamily(product, accessories) {
+    var same = accessories.filter(function (a) {
+      return a.colorFamily === product.colorFamily;
+    });
+    return same.length ? same : accessories;
+  }
+
+  function fillSlots(slots, products, qtyPer, catalogApi) {
+    var placements = {};
+    var pi = 0;
+    slots.forEach(function (slot) {
+      if (pi >= products.length) return;
+      var product = products[pi];
+      var qty = Math.min(qtyPer || 1, slot.maxUnits);
+      placements[slot.id] = {
+        sku: product.sku,
+        qty: qty,
+        facing: pickFacing(slot, product),
+      };
+      pi += 1;
+    });
+    return { placements: placements, used: pi, catalogApi: catalogApi };
+  }
+
+  /**
+   * @param {object} opts
+   * @param {Array} opts.catalog
+   * @param {object} opts.fixture
+   * @param {object} opts.rules { colorFlow, crossMerch, coordinatePairing }
+   * @param {object} opts.helpers { isTop, isBottom, isAccessory }
+   */
+  function autoGenerate(opts) {
+    var catalog = clone(opts.catalog);
+    var fixture = opts.fixture;
+    var rules = opts.rules || {};
+    var H = opts.helpers;
+    var notes = [];
+
+    var tops = catalog.filter(H.isTop);
+    var bottoms = catalog.filter(H.isBottom);
+    var bags = catalog.filter(H.isAccessory);
+
+    if (rules.colorFlow) {
+      tops.sort(byLightToDark);
+      bottoms.sort(byLightToDark);
+      bags.sort(byLightToDark);
+      catalog.sort(byLightToDark);
+      notes.push("Color flow: apparel sequenced light → dark using relative luminance of colorHex.");
+    }
+
+    var slots = fixture.slots;
+    var placements = {};
+
+    var upper = slots.filter(function (s) {
+      return s.role === "hanging-upper" || (s.role === "hanging-arm" && s.armIndex < 2);
+    });
+    var lowerHang = slots.filter(function (s) {
+      return s.role === "hanging-lower" || (s.role === "hanging-arm" && s.armIndex >= 2);
+    });
+    var hangingAll = slots.filter(function (s) {
+      return s.kind === "hanging";
+    });
+    var shelves = slots.filter(function (s) {
+      return s.role === "shelf-lower" || s.role === "table-lower" || s.kind === "shelf";
+    });
+    var tableUpper = slots.filter(function (s) {
+      return s.role === "table-upper";
+    });
+    var pegs = slots.filter(function (s) {
+      return s.kind === "peg";
+    });
+
+    function expandTo(products, n) {
+      if (!products.length || n <= 0) return [];
+      var out = [];
+      var i = 0;
+      while (out.length < n) {
+        out.push(products[i % products.length]);
+        i += 1;
+      }
+      return out;
+    }
+
+    function placeList(slotList, products) {
+      var empty = slotList.filter(function (slot) {
+        return !placements[slot.id];
+      });
+      var seq = expandTo(products, empty.length);
+      var idx = 0;
+      empty.forEach(function (slot) {
+        if (idx >= seq.length) return;
+        var product = seq[idx];
+        placements[slot.id] = {
+          sku: product.sku,
+          qty: Math.min(slot.kind === "shelf" ? Math.max(1, Math.min(2, slot.maxUnits)) : 1, slot.maxUnits),
+          facing: pickFacing(slot, product),
+        };
+        idx += 1;
+      });
+      return idx;
+    }
+
+    if (fixture.id === "nestingTable") {
+      var foldedApparel = catalog.filter(function (p) {
+        return !H.isAccessory(p);
+      });
+      if (rules.coordinatePairing) {
+        notes.push("Coordinate pairing: tops on the upper table, matching bottoms on the lower table.");
+        placeList(tableUpper, tops);
+        var lowerTable = slots.filter(function (s) {
+          return s.role === "table-lower";
+        });
+        var pairedBottoms = [];
+        tops.forEach(function (t) {
+          var match = bottoms.filter(function (b) {
+            return b.colorFamily === t.colorFamily;
+          });
+          match.forEach(function (m) {
+            if (pairedBottoms.indexOf(m) === -1) pairedBottoms.push(m);
+          });
+        });
+        bottoms.forEach(function (b) {
+          if (pairedBottoms.indexOf(b) === -1) pairedBottoms.push(b);
+        });
+        placeList(lowerTable, pairedBottoms.length ? pairedBottoms : bottoms);
+      } else {
+        placeList(tableUpper, foldedApparel);
+        placeList(
+          slots.filter(function (s) {
+            return s.role === "table-lower";
+          }),
+          foldedApparel
+        );
+      }
+    } else if (rules.coordinatePairing && upper.length && lowerHang.length) {
+      notes.push("Coordinate pairing: tops on upper hanging tiers / front arms; bottoms on lower tiers / rear arms.");
+      placeList(upper, tops);
+      var familyOrder = [];
+      upper.forEach(function (slot) {
+        var pl = placements[slot.id];
+        if (!pl) return;
+        var prod = catalog.find(function (p) {
+          return p.sku === pl.sku;
+        });
+        if (prod && familyOrder.indexOf(prod.colorFamily) === -1) {
+          familyOrder.push(prod.colorFamily);
+        }
+      });
+      var orderedBottoms = [];
+      familyOrder.forEach(function (fam) {
+        bottoms.forEach(function (b) {
+          if (b.colorFamily === fam && orderedBottoms.indexOf(b) === -1) orderedBottoms.push(b);
+        });
+      });
+      bottoms.forEach(function (b) {
+        if (orderedBottoms.indexOf(b) === -1) orderedBottoms.push(b);
+      });
+      placeList(lowerHang, orderedBottoms.length ? orderedBottoms : bottoms);
+    } else {
+      var wear = catalog.filter(function (p) {
+        return !H.isAccessory(p);
+      });
+      placeList(hangingAll.length ? hangingAll : slots, wear);
+    }
+
+    if (rules.crossMerch && bags.length) {
+      notes.push("Cross-merchandising: accessories injected onto lower shelf and side pegs, matched by color family.");
+      var accessorySlots = pegs.concat(
+        shelves.filter(function (s) {
+          return s.role === "shelf-lower" || s.role === "table-lower" || s.kind === "peg";
+        })
+      );
+      if (!accessorySlots.length) accessorySlots = shelves;
+
+      var neighborFamilies = [];
+      Object.keys(placements).forEach(function (sid) {
+        var sku = placements[sid].sku;
+        var prod = catalog.find(function (p) {
+          return p.sku === sku;
+        });
+        if (prod && neighborFamilies.indexOf(prod.colorFamily) === -1) {
+          neighborFamilies.push(prod.colorFamily);
+        }
+      });
+
+      var bagQueue = [];
+      neighborFamilies.forEach(function (fam) {
+        bags.forEach(function (bag) {
+          if (bag.colorFamily === fam && bagQueue.indexOf(bag) === -1) bagQueue.push(bag);
+        });
+      });
+      bags.forEach(function (bag) {
+        if (bagQueue.indexOf(bag) === -1) bagQueue.push(bag);
+      });
+
+      var bi = 0;
+      accessorySlots.forEach(function (slot) {
+        if (!bagQueue.length) return;
+        var isAccessoryHome =
+          slot.kind === "peg" ||
+          slot.role === "shelf-lower" ||
+          (slot.role === "table-lower" && bi < 4);
+        if (!isAccessoryHome && placements[slot.id]) return;
+        var bag = bagQueue[bi % bagQueue.length];
+        placements[slot.id] = {
+          sku: bag.sku,
+          qty: Math.min(2, slot.maxUnits),
+          facing: pickFacing(slot, bag),
+        };
+        bi += 1;
+      });
+    }
+
+    var units = 0;
+    Object.keys(placements).forEach(function (id) {
+      units += placements[id].qty;
+    });
+
+    return {
+      placements: placements,
+      units: units,
+      capacity: fixture.capacity,
+      notes: notes,
+      rules: rules,
+    };
+  }
+
+  function utilization(placements, capacity) {
+    var units = 0;
+    Object.keys(placements || {}).forEach(function (id) {
+      units += placements[id].qty || 0;
+    });
+    return { units: units, capacity: capacity, label: units + "/" + capacity + " items placed" };
+  }
+
+  function billOfMaterials(placements, getBySku) {
+    var map = {};
+    Object.keys(placements || {}).forEach(function (slotId) {
+      var pl = placements[slotId];
+      if (!pl) return;
+      if (!map[pl.sku]) {
+        var product = getBySku(pl.sku);
+        map[pl.sku] = {
+          sku: pl.sku,
+          name: product ? product.name : pl.sku,
+          category: product ? product.category : "",
+          image: product ? product.image : "",
+          colorHex: product ? product.colorHex : "#ccc",
+          facingCounts: {},
+          units: 0,
+          slots: 0,
+        };
+      }
+      map[pl.sku].units += pl.qty;
+      map[pl.sku].slots += 1;
+      map[pl.sku].facingCounts[pl.facing] = (map[pl.sku].facingCounts[pl.facing] || 0) + 1;
+    });
+    return Object.keys(map)
+      .sort()
+      .map(function (sku) {
+        return map[sku];
+      });
+  }
+
+  function merchandisingNotes(fixture, result) {
+    var lines = [];
+    lines.push("Fixture: " + fixture.name + " — " + fixture.subtitle + ".");
+    lines.push("Target density: fill each snap point; do not mix SKUs on a single slot.");
+    if (fixture.id === "fourWay") {
+      lines.push("Hang North/East arms as the color-story front; South/West hold coordinated bottoms.");
+      lines.push("Side pegs carry bags that echo the nearest arm's color family.");
+    }
+    if (fixture.id === "wallBay") {
+      lines.push("Upper bar: jackets and tees. Lower bar: trousers and skirts. Shelf: folded backups + accessories.");
+      lines.push("Face hangers forward unless the SKU default is HANG_SIDE (trousers).");
+    }
+    if (fixture.id === "nestingTable") {
+      lines.push("Keep stacks squared to the table edge. Count badges must match on-hand units.");
+      lines.push("Lower table holds bottoms and bags; upper table holds tops.");
+    }
+    (result.notes || []).forEach(function (n) {
+      lines.push(n);
+    });
+    lines.push("Restore any size run left-to-right XS → XL within a SKU block after color flow is set.");
+    return lines;
+  }
+
+  return {
+    hexLuminance: hexLuminance,
+    byLightToDark: byLightToDark,
+    autoGenerate: autoGenerate,
+    utilization: utilization,
+    billOfMaterials: billOfMaterials,
+    merchandisingNotes: merchandisingNotes,
+    matchingFamily: matchingFamily,
+    fillSlots: fillSlots,
+  };
+});

--- a/planogram/js/algorithm.test.js
+++ b/planogram/js/algorithm.test.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+"use strict";
+
+var assert = require("assert");
+var catalog = require("./catalog");
+var fixtures = require("./fixtures");
+var algo = require("./algorithm");
+
+assert.strictEqual(catalog.PRODUCTS.length, 15, "catalog must have 15 items");
+
+["sku", "name", "category", "colorHex", "colorFamily", "price", "defaultFacing", "image", "cutout"].forEach(function (key) {
+  catalog.PRODUCTS.forEach(function (p) {
+    assert.ok(p[key], p.sku + " missing " + key);
+  });
+});
+
+var facings = { HANG_FORWARD: 1, HANG_SIDE: 1, FOLDED: 1, MANNEQUIN: 1 };
+catalog.PRODUCTS.forEach(function (p) {
+  assert.ok(facings[p.defaultFacing], "invalid facing " + p.defaultFacing);
+});
+
+var cats = {};
+catalog.PRODUCTS.forEach(function (p) {
+  cats[p.category] = true;
+});
+["jackets", "tees", "trousers", "skirts", "bags"].forEach(function (c) {
+  assert.ok(cats[c], "missing category " + c);
+});
+
+assert.strictEqual(fixtures.TEMPLATES.length, 3);
+["fourWay", "wallBay", "nestingTable"].forEach(function (id) {
+  var f = fixtures.getById(id);
+  assert.ok(f.slots.length > 0, id + " has slots");
+  assert.ok(f.capacity >= 24, id + " capacity");
+});
+
+assert.strictEqual(fixtures.getById("fourWay").capacity, 40);
+assert.strictEqual(fixtures.getById("wallBay").capacity, 40);
+
+var ivory = catalog.PRODUCTS.find(function (p) {
+  return p.sku === "TEE-2201";
+});
+var charcoal = catalog.PRODUCTS.find(function (p) {
+  return p.sku === "TRS-3302";
+});
+assert.ok(algo.hexLuminance(ivory.colorHex) > algo.hexLuminance(charcoal.colorHex));
+
+var helpers = {
+  isTop: catalog.isTop,
+  isBottom: catalog.isBottom,
+  isAccessory: catalog.isAccessory,
+};
+
+var wall = fixtures.getById("wallBay");
+var result = algo.autoGenerate({
+  catalog: catalog.PRODUCTS,
+  fixture: wall,
+  rules: { colorFlow: true, crossMerch: true, coordinatePairing: true },
+  helpers: helpers,
+});
+
+assert.ok(Object.keys(result.placements).length > 0, "placements created");
+
+var upperSku = result.placements["bar-1-0"];
+assert.ok(upperSku, "upper bar filled");
+assert.ok(catalog.isTop(catalog.getBySku(upperSku.sku)), "upper bar should be a top");
+
+var lowerSku = result.placements["bar-2-0"];
+assert.ok(lowerSku, "lower bar filled");
+assert.ok(catalog.isBottom(catalog.getBySku(lowerSku.sku)), "lower bar should be a bottom");
+
+var peg = result.placements["wall-peg-0"];
+assert.ok(peg, "peg filled");
+assert.ok(catalog.isAccessory(catalog.getBySku(peg.sku)), "peg should be accessory");
+
+var orderedTops = [];
+wall.slots
+  .filter(function (s) {
+    return s.role === "hanging-upper";
+  })
+  .forEach(function (s) {
+    var pl = result.placements[s.id];
+    if (pl) orderedTops.push(catalog.getBySku(pl.sku));
+  });
+var uniqueTopCount = catalog.PRODUCTS.filter(catalog.isTop).length;
+for (var i = 1; i < Math.min(orderedTops.length, uniqueTopCount); i++) {
+  assert.ok(
+    algo.hexLuminance(orderedTops[i - 1].colorHex) + 1e-9 >= algo.hexLuminance(orderedTops[i].colorHex),
+    "color flow light to dark on upper bar"
+  );
+}
+
+var util = algo.utilization(result.placements, wall.capacity);
+assert.ok(util.units <= util.capacity);
+assert.ok(util.units >= 30, "auto-planogram should fill most of the bay");
+assert.ok(/items placed/.test(util.label));
+
+var bom = algo.billOfMaterials(result.placements, catalog.getBySku);
+assert.ok(bom.length >= 3);
+assert.ok(bom[0].sku);
+assert.ok(bom[0].units >= 1);
+
+var four = algo.autoGenerate({
+  catalog: catalog.PRODUCTS,
+  fixture: fixtures.getById("fourWay"),
+  rules: { colorFlow: true, crossMerch: true, coordinatePairing: true },
+  helpers: helpers,
+});
+var armN = four.placements["arm-n-0"];
+var armS = four.placements["arm-s-0"];
+assert.ok(catalog.isTop(catalog.getBySku(armN.sku)));
+assert.ok(catalog.isBottom(catalog.getBySku(armS.sku)));
+
+var table = algo.autoGenerate({
+  catalog: catalog.PRODUCTS,
+  fixture: fixtures.getById("nestingTable"),
+  rules: { colorFlow: true, crossMerch: true, coordinatePairing: true },
+  helpers: helpers,
+});
+assert.ok(catalog.isTop(catalog.getBySku(table.placements["table-u-0"].sku)));
+
+var notes = algo.merchandisingNotes(wall, result);
+assert.ok(notes.length >= 3);
+
+console.log("planogram tests passed");
+console.log("  catalog", catalog.PRODUCTS.length);
+console.log("  wall utilization", util.label);
+console.log("  BOM lines", bom.length);

--- a/planogram/js/app.js
+++ b/planogram/js/app.js
@@ -1,0 +1,606 @@
+(function () {
+  var NS = "http://www.w3.org/2000/svg";
+  var catalog = window.PlanogramCatalog;
+  var fixtures = window.PlanogramFixtures;
+  var algo = window.PlanogramAlgorithm;
+
+  var state = {
+    fixtureId: "fourWay",
+    placements: {},
+    selectedSlot: null,
+    lastNotes: [],
+    audit: {},
+    photoUrl: null,
+    tab: "workspace",
+  };
+
+  function fixture() {
+    return fixtures.getById(state.fixtureId);
+  }
+
+  function slotById(id) {
+    return fixture().slots.find(function (s) {
+      return s.id === id;
+    });
+  }
+
+  function el(tag, attrs, children) {
+    var node = document.createElementNS(NS, tag);
+    Object.keys(attrs || {}).forEach(function (k) {
+      if (k === "text") node.textContent = attrs[k];
+      else node.setAttribute(k, attrs[k]);
+    });
+    (children || []).forEach(function (c) {
+      node.appendChild(c);
+    });
+    return node;
+  }
+
+  function drawFrame(svg, f) {
+    var g = el("g", { class: "fixture-frame", fill: "none", stroke: "#1c1917", "stroke-width": "2" });
+    if (f.frame === "fourWay") {
+      g.appendChild(el("circle", { cx: "400", cy: "290", r: "22", fill: "#c4a574", stroke: "#1c1917" }));
+      g.appendChild(el("circle", { cx: "400", cy: "290", r: "8", fill: "#1c1917" }));
+      [
+        ["400", "70", "400", "510"],
+        ["90", "290", "710", "290"],
+      ].forEach(function (d) {
+        g.appendChild(el("line", { x1: d[0], y1: d[1], x2: d[2], y2: d[3], "stroke-width": "10", stroke: "#d6cbb8" }));
+        g.appendChild(el("line", { x1: d[0], y1: d[1], x2: d[2], y2: d[3], "stroke-width": "2", stroke: "#1c1917" }));
+      });
+      [
+        ["400", "52", "N"],
+        ["728", "294", "E"],
+        ["400", "528", "S"],
+        ["72", "294", "W"],
+      ].forEach(function (lab) {
+        g.appendChild(
+          el("text", {
+            x: lab[0],
+            y: lab[1],
+            fill: "#57534e",
+            "font-size": "11",
+            "font-family": "Outfit, sans-serif",
+            "text-anchor": "middle",
+            text: lab[2],
+          })
+        );
+      });
+    } else if (f.frame === "wallBay") {
+      g.appendChild(el("rect", { x: "28", y: "28", width: "660", height: "460", rx: "8", fill: "#f7f1e8", stroke: "#1c1917" }));
+      g.appendChild(el("line", { x1: "40", y1: "48", x2: "676", y2: "48", "stroke-width": "8", stroke: "#8a7354" }));
+      g.appendChild(el("line", { x1: "40", y1: "200", x2: "676", y2: "200", "stroke-width": "8", stroke: "#8a7354" }));
+      g.appendChild(el("rect", { x: "40", y: "388", width: "636", height: "18", fill: "#c4a574", stroke: "#1c1917" }));
+      g.appendChild(el("rect", { x: "700", y: "28", width: "72", height: "460", rx: "8", fill: "#efe6d8", stroke: "#1c1917" }));
+      g.appendChild(el("text", { x: "358", y: "44", fill: "#57534e", "font-size": "11", "text-anchor": "middle", text: "UPPER HANGING BAR" }));
+      g.appendChild(el("text", { x: "358", y: "196", fill: "#57534e", "font-size": "11", "text-anchor": "middle", text: "LOWER HANGING BAR" }));
+      g.appendChild(el("text", { x: "358", y: "384", fill: "#57534e", "font-size": "11", "text-anchor": "middle", text: "LOWER SHELF" }));
+      g.appendChild(el("text", { x: "736", y: "48", fill: "#57534e", "font-size": "10", "text-anchor": "middle", text: "PEGS" }));
+    } else {
+      g.appendChild(
+        el("polygon", {
+          points: "70,60 650,60 700,250 40,250",
+          fill: "#efe6d8",
+          stroke: "#1c1917",
+        })
+      );
+      g.appendChild(el("line", { x1: "70", y1: "60", x2: "40", y2: "250", stroke: "#1c1917" }));
+      g.appendChild(el("line", { x1: "650", y1: "60", x2: "700", y2: "250", stroke: "#1c1917" }));
+      g.appendChild(
+        el("polygon", {
+          points: "110,280 710,280 760,480 80,480",
+          fill: "#e7dcc8",
+          stroke: "#1c1917",
+        })
+      );
+      g.appendChild(el("text", { x: "360", y: "52", fill: "#57534e", "font-size": "11", "text-anchor": "middle", text: "UPPER TABLE" }));
+      g.appendChild(el("text", { x: "400", y: "272", fill: "#57534e", "font-size": "11", "text-anchor": "middle", text: "LOWER TABLE" }));
+    }
+    svg.appendChild(g);
+  }
+
+  function garmentShape(product, facing, x, y, w, h) {
+    var g = el("g", { transform: "translate(" + x + " " + y + ")" });
+    var hex = product.colorHex;
+    if (facing === "FOLDED") {
+      var layers = 3;
+      for (var i = layers - 1; i >= 0; i--) {
+        g.appendChild(
+          el("rect", {
+            x: String(4 + i * 2),
+            y: String(6 + i * 3),
+            width: String(w - 14),
+            height: String(h - 18),
+            rx: "4",
+            fill: hex,
+            stroke: "#1c1917",
+            "stroke-width": "1.2",
+            opacity: String(0.55 + i * 0.15),
+          })
+        );
+      }
+    } else if (facing === "HANG_SIDE") {
+      for (var s = 0; s < 4; s++) {
+        g.appendChild(
+          el("rect", {
+            x: String(8 + s * 6),
+            y: "8",
+            width: "8",
+            height: String(h - 16),
+            rx: "2",
+            fill: hex,
+            stroke: "#1c1917",
+            "stroke-width": "1",
+          })
+        );
+      }
+      g.appendChild(el("line", { x1: "6", y1: "10", x2: String(w - 8), y2: "10", stroke: "#1c1917" }));
+    } else if (facing === "MANNEQUIN") {
+      g.appendChild(el("circle", { cx: String(w / 2), cy: "12", r: "7", fill: "#e8dcc8", stroke: "#1c1917" }));
+      g.appendChild(
+        el("path", {
+          d: "M" + w / 2 + " 19 L" + (w / 2 - 14) + " " + (h - 8) + " L" + (w / 2 + 14) + " " + (h - 8) + " Z",
+          fill: hex,
+          stroke: "#1c1917",
+        })
+      );
+    } else {
+      var cat = product.category;
+      if (cat === "bags") {
+        g.appendChild(el("path", { d: "M14 16c0-8 6-12 10-12s10 4 10 12", fill: "none", stroke: "#1c1917" }));
+        g.appendChild(el("rect", { x: "8", y: "16", width: String(w - 18), height: String(h - 26), rx: "4", fill: hex, stroke: "#1c1917" }));
+      } else if (cat === "trousers") {
+        g.appendChild(
+          el("path", {
+            d: "M12 10 h" + (w - 24) + " l3 8 l-6 " + (h - 24) + " h-6 v-" + (h - 40) + " l-2 " + (h - 40) + " h-6 z",
+            fill: hex,
+            stroke: "#1c1917",
+          })
+        );
+      } else if (cat === "skirts") {
+        g.appendChild(
+          el("path", {
+            d: "M16 10 h" + (w - 32) + " l6 8 l-8 " + (h - 26) + " H18 z",
+            fill: hex,
+            stroke: "#1c1917",
+          })
+        );
+      } else {
+        g.appendChild(
+          el("path", {
+            d: "M18 8 l-10 12 6 5 4-4 v" + (h - 32) + " h" + (w - 36) + " v-" + (h - 32) + " l4 4 6-5 -10-12 h-10 z",
+            fill: hex,
+            stroke: "#1c1917",
+            "stroke-linejoin": "round",
+          })
+        );
+      }
+    }
+    return g;
+  }
+
+  function hitSlot(svg, clientX, clientY) {
+    var pt = svg.createSVGPoint();
+    pt.x = clientX;
+    pt.y = clientY;
+    var ctm = svg.getScreenCTM();
+    if (!ctm) return null;
+    var loc = pt.matrixTransform(ctm.inverse());
+    return fixture().slots.find(function (slot) {
+      return loc.x >= slot.x && loc.x <= slot.x + slot.w && loc.y >= slot.y && loc.y <= slot.y + slot.h;
+    }) || null;
+  }
+
+  function renderCanvas(targetSvg, readOnly) {
+    var f = fixture();
+    targetSvg.setAttribute("viewBox", f.viewBox);
+    targetSvg.innerHTML = "";
+    drawFrame(targetSvg, f);
+
+    f.slots.forEach(function (slot) {
+      var group = el("g", {
+        class: "snap-slot",
+        "data-slot": slot.id,
+      });
+      var selected = state.selectedSlot === slot.id;
+      group.appendChild(
+        el("rect", {
+          x: String(slot.x),
+          y: String(slot.y),
+          width: String(slot.w),
+          height: String(slot.h),
+          rx: "6",
+          fill: selected ? "rgba(143,45,36,0.12)" : "rgba(28,25,23,0.04)",
+          stroke: selected ? "#8f2d24" : "#c4b7a0",
+          "stroke-dasharray": selected ? "0" : "3 3",
+          "stroke-width": selected ? "2" : "1",
+        })
+      );
+
+      var pl = state.placements[slot.id];
+      if (pl) {
+        var product = catalog.getBySku(pl.sku);
+        if (product) {
+          group.appendChild(garmentShape(product, pl.facing, slot.x, slot.y, slot.w, slot.h));
+          if (pl.qty > 1 || pl.facing === "FOLDED" || pl.facing === "HANG_SIDE") {
+            var badge = el("g", {});
+            badge.appendChild(
+              el("circle", {
+                cx: String(slot.x + slot.w - 8),
+                cy: String(slot.y + 10),
+                r: "9",
+                fill: "#1c1917",
+              })
+            );
+            badge.appendChild(
+              el("text", {
+                x: String(slot.x + slot.w - 8),
+                y: String(slot.y + 14),
+                fill: "#fffaf3",
+                "font-size": "10",
+                "text-anchor": "middle",
+                "font-family": "Outfit, sans-serif",
+                text: String(pl.qty),
+              })
+            );
+            group.appendChild(badge);
+          }
+        }
+      }
+
+      if (!readOnly) {
+        group.style.cursor = "pointer";
+      }
+      targetSvg.appendChild(group);
+    });
+
+    if (readOnly) return;
+
+    targetSvg.ondragover = function (ev) {
+      ev.preventDefault();
+      var slot = hitSlot(targetSvg, ev.clientX, ev.clientY);
+      targetSvg.querySelectorAll(".snap-slot rect").forEach(function (r) {
+        r.setAttribute("stroke", "#c4b7a0");
+      });
+      if (slot) {
+        var node = targetSvg.querySelector('[data-slot="' + slot.id + '"] rect');
+        if (node) node.setAttribute("stroke", "#8f2d24");
+      }
+    };
+    targetSvg.ondrop = function (ev) {
+      ev.preventDefault();
+      var sku = ev.dataTransfer.getData("text/sku") || ev.dataTransfer.getData("text/plain");
+      var slot = hitSlot(targetSvg, ev.clientX, ev.clientY);
+      if (sku && slot) placeOnSlot(slot.id, sku);
+    };
+    targetSvg.onclick = function (ev) {
+      var slot = hitSlot(targetSvg, ev.clientX, ev.clientY);
+      state.selectedSlot = slot ? slot.id : null;
+      renderAll();
+    };
+  }
+
+  function placeOnSlot(slotId, sku) {
+    var slot = slotById(slotId);
+    var product = catalog.getBySku(sku);
+    if (!slot || !product) return;
+    var existing = state.placements[slotId];
+    if (existing && existing.sku === sku) {
+      existing.qty = Math.min(slot.maxUnits, existing.qty + 1);
+    } else {
+      var facing = product.defaultFacing;
+      if (slot.allowedFacings.indexOf(facing) === -1) facing = slot.allowedFacings[0];
+      state.placements[slotId] = { sku: sku, qty: 1, facing: facing };
+    }
+    state.selectedSlot = slotId;
+    renderAll();
+  }
+
+  function updateCapacity() {
+    var util = algo.utilization(state.placements, fixture().capacity);
+    document.getElementById("cap-label").textContent = util.label;
+    document.getElementById("cap-bar").style.width = Math.min(100, (util.units / util.capacity) * 100) + "%";
+  }
+
+  function renderCatalog() {
+    var root = document.getElementById("catalog");
+    root.innerHTML = "";
+    catalog.PRODUCTS.forEach(function (p) {
+      var card = document.createElement("div");
+      card.className = "sku-card";
+      card.draggable = true;
+      card.innerHTML =
+        '<img alt="" src="' +
+        p.image +
+        '"><div class="name">' +
+        p.name +
+        '</div><div class="meta"><span><i class="swatch" style="background:' +
+        p.colorHex +
+        '"></i>' +
+        p.sku +
+        "</span><span>$" +
+        p.price +
+        "</span></div>";
+      card.addEventListener("dragstart", function (ev) {
+        ev.dataTransfer.setData("text/sku", p.sku);
+        ev.dataTransfer.setData("text/plain", p.sku);
+        ev.dataTransfer.effectAllowed = "copy";
+      });
+      card.addEventListener("click", function () {
+        if (state.selectedSlot) placeOnSlot(state.selectedSlot, p.sku);
+      });
+      root.appendChild(card);
+    });
+  }
+
+  function renderFixtures() {
+    var root = document.getElementById("fixture-picks");
+    root.innerHTML = "";
+    fixtures.TEMPLATES.forEach(function (f) {
+      var b = document.createElement("button");
+      b.type = "button";
+      b.className = f.id === state.fixtureId ? "active" : "";
+      b.innerHTML = "<strong>" + f.name + "</strong><small>" + f.subtitle + " · " + f.capacity + " unit capacity</small>";
+      b.addEventListener("click", function () {
+        state.fixtureId = f.id;
+        state.placements = {};
+        state.selectedSlot = null;
+        renderAll();
+      });
+      root.appendChild(b);
+    });
+  }
+
+  function renderInspector() {
+    var panel = document.getElementById("inspector-panel");
+    var slot = state.selectedSlot ? slotById(state.selectedSlot) : null;
+    var pl = slot ? state.placements[slot.id] : null;
+    if (!slot) {
+      panel.innerHTML = '<p class="empty">Select a snap point, then drop a SKU from the catalog. Click a catalog card to fill the selected slot.</p>';
+      return;
+    }
+    var product = pl ? catalog.getBySku(pl.sku) : null;
+    var html = "<p><strong>Slot</strong> " + slot.id + "<br><span class='hint'>" + slot.kind + " · max " + slot.maxUnits + "</span></p>";
+    if (!product) {
+      html += "<p class='empty'>Empty. Drag an item here.</p>";
+      panel.innerHTML = html;
+      return;
+    }
+    html +=
+      '<img alt="" src="' +
+      product.image +
+      '" style="width:100%;height:90px;object-fit:contain;background:#f7f1e8;border-radius:8px">' +
+      "<p><strong>" +
+      product.name +
+      "</strong><br>" +
+      product.sku +
+      " · " +
+      product.colorFamily +
+      "</p>" +
+      '<label class="hint">Facing</label><select class="facing" id="facing-select"></select>' +
+      '<div class="qty-row"><button type="button" id="qty-minus">−</button><strong id="qty-val"></strong><button type="button" id="qty-plus">+</button></div>' +
+      '<button type="button" class="btn ghost" id="clear-slot">Remove from slot</button>';
+    panel.innerHTML = html;
+    var sel = document.getElementById("facing-select");
+    slot.allowedFacings.forEach(function (f) {
+      var o = document.createElement("option");
+      o.value = f;
+      o.textContent = f.replace(/_/g, " ");
+      if (f === pl.facing) o.selected = true;
+      sel.appendChild(o);
+    });
+    sel.addEventListener("change", function () {
+      pl.facing = sel.value;
+      renderAll();
+    });
+    document.getElementById("qty-val").textContent = pl.qty;
+    document.getElementById("qty-minus").onclick = function () {
+      pl.qty = Math.max(1, pl.qty - 1);
+      renderAll();
+    };
+    document.getElementById("qty-plus").onclick = function () {
+      pl.qty = Math.min(slot.maxUnits, pl.qty + 1);
+      renderAll();
+    };
+    document.getElementById("clear-slot").onclick = function () {
+      delete state.placements[slot.id];
+      renderAll();
+    };
+  }
+
+  function currentRules() {
+    return {
+      colorFlow: document.getElementById("rule-color").checked,
+      crossMerch: document.getElementById("rule-cross").checked,
+      coordinatePairing: document.getElementById("rule-pair").checked,
+    };
+  }
+
+  function autoGenerate() {
+    var result = algo.autoGenerate({
+      catalog: catalog.PRODUCTS,
+      fixture: fixture(),
+      rules: currentRules(),
+      helpers: {
+        isTop: catalog.isTop,
+        isBottom: catalog.isBottom,
+        isAccessory: catalog.isAccessory,
+      },
+    });
+    state.placements = result.placements;
+    state.lastNotes = algo.merchandisingNotes(fixture(), result);
+    state.selectedSlot = null;
+    renderAll();
+  }
+
+  function exportWorkOrder() {
+    var f = fixture();
+    var bom = algo.billOfMaterials(state.placements, catalog.getBySku);
+    var notes = state.lastNotes.length
+      ? state.lastNotes
+      : algo.merchandisingNotes(f, { notes: [] });
+    var util = algo.utilization(state.placements, f.capacity);
+    var visual = document.getElementById("fixture-svg").outerHTML;
+    var rows = bom
+      .map(function (row) {
+        var facings = Object.keys(row.facingCounts)
+          .map(function (k) {
+            return k.replace(/_/g, " ") + " ×" + row.facingCounts[k];
+          })
+          .join(", ");
+        return (
+          "<tr><td>" +
+          row.sku +
+          '</td><td><img class="thumb" src="' +
+          row.image +
+          '"></td><td>' +
+          row.name +
+          "</td><td>" +
+          facings +
+          "</td><td>" +
+          row.units +
+          "</td></tr>"
+        );
+      })
+      .join("");
+    var sheet =
+      '<div class="print-sheet">' +
+      "<h1>Visual Work Order</h1>" +
+      "<p>Atelier Planogram · " +
+      f.name +
+      " · " +
+      util.label +
+      " · " +
+      new Date().toLocaleDateString() +
+      "</p>" +
+      '<div class="print-visual">' +
+      visual +
+      "</div>" +
+      "<h2>Bill of Materials / SKU pick list</h2>" +
+      "<table><thead><tr><th>SKU</th><th>Image</th><th>Item Name</th><th>Facing Count</th><th>Units</th></tr></thead><tbody>" +
+      (rows || "<tr><td colspan=5>No merchandise placed.</td></tr>") +
+      "</tbody></table>" +
+      "<h2>Merchandising guidelines</h2><ol>" +
+      notes
+        .map(function (n) {
+          return "<li>" + n + "</li>";
+        })
+        .join("") +
+      "</ol></div>";
+    document.getElementById("print-root").innerHTML = sheet;
+    window.print();
+  }
+
+  function renderAuditPreview() {
+    var svg = document.getElementById("audit-svg");
+    renderCanvas(svg, true);
+    var list = document.getElementById("audit-list");
+    var bom = algo.billOfMaterials(state.placements, catalog.getBySku);
+    list.innerHTML = "";
+    if (!bom.length) {
+      list.innerHTML = "<p class='empty'>Generate or build a planogram first. Checklist items appear from placed SKUs.</p>";
+      updateScore();
+      return;
+    }
+    bom.forEach(function (row) {
+      if (!state.audit[row.sku]) state.audit[row.sku] = "unset";
+      var div = document.createElement("div");
+      div.className = "check-row";
+      div.innerHTML =
+        '<img alt="" src="' +
+        row.image +
+        '"><div><strong>' +
+        row.sku +
+        "</strong><br>" +
+        row.name +
+        " · " +
+        row.units +
+        ' units</div><div class="seg">' +
+        '<button type="button" data-v="pass">Pass</button>' +
+        '<button type="button" data-v="fail">Fail</button></div>';
+      var buttons = div.querySelectorAll("button");
+      function paint() {
+        buttons[0].className = state.audit[row.sku] === "pass" ? "on-pass" : "";
+        buttons[1].className = state.audit[row.sku] === "fail" ? "on-fail" : "";
+      }
+      buttons.forEach(function (b) {
+        b.addEventListener("click", function () {
+          state.audit[row.sku] = b.getAttribute("data-v");
+          paint();
+          updateScore();
+        });
+      });
+      paint();
+      list.appendChild(div);
+    });
+    updateScore();
+  }
+
+  function updateScore() {
+    var bom = algo.billOfMaterials(state.placements, catalog.getBySku);
+    var marked = bom.filter(function (r) {
+      return state.audit[r.sku] === "pass" || state.audit[r.sku] === "fail";
+    });
+    var passed = marked.filter(function (r) {
+      return state.audit[r.sku] === "pass";
+    }).length;
+    var pct = marked.length ? Math.round((passed / marked.length) * 100) : 0;
+    document.getElementById("audit-score").textContent = pct + "%";
+    document.getElementById("audit-score-meta").textContent =
+      passed + " pass / " + (marked.length - passed) + " fail · " + (bom.length - marked.length) + " unmarked of " + bom.length + " SKUs";
+  }
+
+  function renderAll() {
+    renderFixtures();
+    renderCanvas(document.getElementById("fixture-svg"), false);
+    renderInspector();
+    updateCapacity();
+    if (state.tab === "audit") renderAuditPreview();
+  }
+
+  function setTab(tab) {
+    state.tab = tab;
+    document.getElementById("workspace").classList.toggle("visible", tab === "workspace");
+    document.getElementById("audit").classList.toggle("visible", tab === "audit");
+    document.getElementById("tab-workspace").classList.toggle("active", tab === "workspace");
+    document.getElementById("tab-audit").classList.toggle("active", tab === "audit");
+    if (tab === "audit") renderAuditPreview();
+  }
+
+  function bind() {
+    document.getElementById("tab-workspace").onclick = function () {
+      setTab("workspace");
+    };
+    document.getElementById("tab-audit").onclick = function () {
+      setTab("audit");
+    };
+    document.getElementById("btn-auto").onclick = autoGenerate;
+    document.getElementById("btn-export").onclick = exportWorkOrder;
+    document.getElementById("btn-clear").onclick = function () {
+      state.placements = {};
+      state.selectedSlot = null;
+      renderAll();
+    };
+    document.getElementById("photo-input").addEventListener("change", function (ev) {
+      var file = ev.target.files && ev.target.files[0];
+      if (!file) return;
+      var url = URL.createObjectURL(file);
+      state.photoUrl = url;
+      var img = document.getElementById("photo-preview");
+      img.src = url;
+      img.style.display = "block";
+      document.getElementById("photo-hint").style.display = "none";
+    });
+    document.addEventListener("keydown", function (ev) {
+      if ((ev.key === "Backspace" || ev.key === "Delete") && state.selectedSlot && state.placements[state.selectedSlot]) {
+        if (document.activeElement && /input|select|textarea/i.test(document.activeElement.tagName)) return;
+        delete state.placements[state.selectedSlot];
+        renderAll();
+      }
+    });
+  }
+
+  renderCatalog();
+  bind();
+  renderAll();
+})();

--- a/planogram/js/catalog.js
+++ b/planogram/js/catalog.js
@@ -1,0 +1,114 @@
+/**
+ * Mock fashion catalog — 15 SKUs with cutout placeholders.
+ * Works in the browser (global) and in Node tests (module.exports).
+ */
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.PlanogramCatalog = factory();
+  }
+})(typeof self !== "undefined" ? self : this, function () {
+  function svgUri(markup) {
+    return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(markup);
+  }
+
+  function hangerHook() {
+    return `<path d="M36 8c0-4 4-7 8-7s8 3 8 7c0 3-2 5-4 6v3" fill="none" stroke="#1c1917" stroke-width="1.6" stroke-linecap="round"/>
+      <path d="M18 18h44l-4 5H22z" fill="#d6c4a8" stroke="#1c1917" stroke-width="1.2"/>`;
+  }
+
+  function cutoutJacket(hex) {
+    return svgUri(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 110">
+      ${hangerHook()}
+      <path d="M22 24l-10 14 8 6 6-8v52l8 6h22l8-6V36l6 8 8-6-10-14-12 4h-22z" fill="${hex}" stroke="#1c1917" stroke-width="1.4" stroke-linejoin="round"/>
+      <path d="M34 24v38l6 8 6-8V24" fill="none" stroke="#1c1917" stroke-width="1.1"/>
+      <circle cx="38" cy="48" r="1.4" fill="#1c1917"/>
+      <circle cx="38" cy="56" r="1.4" fill="#1c1917"/>
+    </svg>`);
+  }
+
+  function cutoutTee(hex) {
+    return svgUri(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 110">
+      ${hangerHook()}
+      <path d="M28 24l-14 10 7 8 7-5v48h24V37l7 5 7-8-14-10-5 3h-10z" fill="${hex}" stroke="#1c1917" stroke-width="1.4" stroke-linejoin="round"/>
+    </svg>`);
+  }
+
+  function cutoutTrouser(hex) {
+    return svgUri(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 110">
+      ${hangerHook()}
+      <path d="M28 22h24l4 8-8 62h-7l-1-40-2 40h-7l-8-62z" fill="${hex}" stroke="#1c1917" stroke-width="1.4" stroke-linejoin="round"/>
+      <path d="M40 30v20" stroke="#1c1917" stroke-width="1"/>
+    </svg>`);
+  }
+
+  function cutoutSkirt(hex) {
+    return svgUri(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 110">
+      ${hangerHook()}
+      <path d="M30 22h20l4 6-10 56H36L26 28z" fill="${hex}" stroke="#1c1917" stroke-width="1.4" stroke-linejoin="round"/>
+      <path d="M32 30h16" stroke="#1c1917" stroke-width="1"/>
+    </svg>`);
+  }
+
+  function cutoutBag(hex) {
+    return svgUri(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 110">
+      <path d="M28 36c0-10 6-16 12-16s12 6 12 16" fill="none" stroke="#1c1917" stroke-width="1.8"/>
+      <rect x="20" y="36" width="40" height="44" rx="4" fill="${hex}" stroke="#1c1917" stroke-width="1.4"/>
+      <rect x="34" y="52" width="12" height="8" rx="1.5" fill="none" stroke="#1c1917" stroke-width="1.1"/>
+    </svg>`);
+  }
+
+  const CUTTERS = {
+    jackets: cutoutJacket,
+    tees: cutoutTee,
+    trousers: cutoutTrouser,
+    skirts: cutoutSkirt,
+    bags: cutoutBag,
+  };
+
+  const PRODUCTS = [
+    { sku: "JKT-0412", name: "Linen Unstructured Blazer", category: "jackets", colorHex: "#F3E6D0", colorFamily: "Ivory", price: 189, defaultFacing: "HANG_FORWARD" },
+    { sku: "JKT-0788", name: "Indigo Trucker Jacket", category: "jackets", colorHex: "#2C4A7C", colorFamily: "Indigo", price: 165, defaultFacing: "HANG_FORWARD" },
+    { sku: "JKT-1104", name: "Camel Cotton Trench", category: "jackets", colorHex: "#C19A6B", colorFamily: "Camel", price: 245, defaultFacing: "MANNEQUIN" },
+    { sku: "TEE-2201", name: "Organic Crew Tee", category: "tees", colorHex: "#F7F4EE", colorFamily: "Ivory", price: 38, defaultFacing: "HANG_FORWARD" },
+    { sku: "TEE-2218", name: "Slub Pocket Tee", category: "tees", colorHex: "#D4B896", colorFamily: "Sand", price: 42, defaultFacing: "HANG_FORWARD" },
+    { sku: "TEE-2240", name: "Charcoal Graphic Tee", category: "tees", colorHex: "#3A3A3A", colorFamily: "Charcoal", price: 48, defaultFacing: "HANG_FORWARD" },
+    { sku: "TEE-2266", name: "Navy Breton Stripe", category: "tees", colorHex: "#1B365D", colorFamily: "Navy", price: 52, defaultFacing: "HANG_FORWARD" },
+    { sku: "TRS-3302", name: "Black Wide-Leg Trouser", category: "trousers", colorHex: "#1A1A1A", colorFamily: "Charcoal", price: 128, defaultFacing: "HANG_SIDE" },
+    { sku: "TRS-3344", name: "Khaki Stretch Chino", category: "trousers", colorHex: "#C3B091", colorFamily: "Sand", price: 98, defaultFacing: "HANG_SIDE" },
+    { sku: "TRS-3371", name: "Olive Pleated Trouser", category: "trousers", colorHex: "#556B2F", colorFamily: "Olive", price: 118, defaultFacing: "HANG_SIDE" },
+    { sku: "SKT-4410", name: "Terracotta Midi Wrap", category: "skirts", colorHex: "#C65D3B", colorFamily: "Terracotta", price: 92, defaultFacing: "HANG_FORWARD" },
+    { sku: "SKT-4428", name: "Blush A-Line Skirt", category: "skirts", colorHex: "#E8B4B8", colorFamily: "Blush", price: 88, defaultFacing: "HANG_FORWARD" },
+    { sku: "BAG-5501", name: "Cognac Structured Tote", category: "bags", colorHex: "#9A5B3C", colorFamily: "Camel", price: 158, defaultFacing: "FOLDED" },
+    { sku: "BAG-5520", name: "Black Crossbody Mini", category: "bags", colorHex: "#222222", colorFamily: "Charcoal", price: 96, defaultFacing: "FOLDED" },
+    { sku: "BAG-5536", name: "Natural Canvas Shopper", category: "bags", colorHex: "#E8DCC4", colorFamily: "Ivory", price: 72, defaultFacing: "FOLDED" },
+  ].map(function (p) {
+    var image = CUTTERS[p.category](p.colorHex);
+    return Object.assign({}, p, {
+      image: image,
+      cutout: image,
+    });
+  });
+
+  var bySku = {};
+  PRODUCTS.forEach(function (p) {
+    bySku[p.sku] = p;
+  });
+
+  return {
+    PRODUCTS: PRODUCTS,
+    getBySku: function (sku) {
+      return bySku[sku] || null;
+    },
+    isTop: function (p) {
+      return p.category === "jackets" || p.category === "tees";
+    },
+    isBottom: function (p) {
+      return p.category === "trousers" || p.category === "skirts";
+    },
+    isAccessory: function (p) {
+      return p.category === "bags";
+    },
+  };
+});

--- a/planogram/js/fixtures.js
+++ b/planogram/js/fixtures.js
@@ -1,0 +1,198 @@
+/**
+ * Fixture templates with snap-point slots.
+ * 4-Way Rack, 3-Tier Wall Bay, Nesting Table.
+ */
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.PlanogramFixtures = factory();
+  }
+})(typeof self !== "undefined" ? self : this, function () {
+  var HANG = ["HANG_FORWARD", "HANG_SIDE", "MANNEQUIN"];
+  var FOLD = ["FOLDED"];
+  var PEG = ["FOLDED", "HANG_FORWARD"];
+
+  function hangingSlot(id, role, x, y, extra) {
+    return Object.assign(
+      {
+        id: id,
+        kind: "hanging",
+        role: role,
+        x: x,
+        y: y,
+        w: 42,
+        h: 72,
+        maxUnits: 1,
+        allowedFacings: HANG,
+      },
+      extra || {}
+    );
+  }
+
+  function shelfSlot(id, role, x, y, extra) {
+    return Object.assign(
+      {
+        id: id,
+        kind: "shelf",
+        role: role,
+        x: x,
+        y: y,
+        w: 52,
+        h: 40,
+        maxUnits: 3,
+        allowedFacings: FOLD,
+      },
+      extra || {}
+    );
+  }
+
+  function pegSlot(id, x, y, extra) {
+    return Object.assign(
+      {
+        id: id,
+        kind: "peg",
+        role: "peg-side",
+        x: x,
+        y: y,
+        w: 44,
+        h: 52,
+        maxUnits: 2,
+        allowedFacings: PEG,
+      },
+      extra || {}
+    );
+  }
+
+  function fourWay() {
+    var slots = [];
+    var hub = { x: 400, y: 290 };
+    var arms = [
+      { key: "n", label: "North", dx: 0, dy: -1, armIndex: 0 },
+      { key: "e", label: "East", dx: 1, dy: 0, armIndex: 1 },
+      { key: "s", label: "South", dx: 0, dy: 1, armIndex: 2 },
+      { key: "w", label: "West", dx: -1, dy: 0, armIndex: 3 },
+    ];
+    arms.forEach(function (arm) {
+      for (var i = 0; i < 8; i++) {
+        var dist = 70 + i * 38;
+        var x = hub.x + arm.dx * dist - 21;
+        var y = hub.y + arm.dy * dist - 36;
+        if (arm.dx === 0) x -= 0;
+        slots.push(
+          hangingSlot("arm-" + arm.key + "-" + i, "hanging-arm", x, y, {
+            armIndex: arm.armIndex,
+            armKey: arm.key,
+            index: i,
+            w: 40,
+            h: 68,
+          })
+        );
+      }
+    });
+    var pegs = [
+      [hub.x - 70, hub.y - 70],
+      [hub.x + 26, hub.y - 70],
+      [hub.x - 70, hub.y + 26],
+      [hub.x + 26, hub.y + 26],
+    ];
+    pegs.forEach(function (p, i) {
+      slots.push(pegSlot("peg-" + i, p[0], p[1], { index: i }));
+    });
+    return {
+      id: "fourWay",
+      name: "4-Way Rack",
+      subtitle: "Four hanging arms + side pegs",
+      viewBox: "0 0 800 580",
+      frame: "fourWay",
+      slots: slots,
+    };
+  }
+
+  function wallBay() {
+    var slots = [];
+    var i;
+    for (i = 0; i < 12; i++) {
+      slots.push(
+        hangingSlot("bar-1-" + i, "hanging-upper", 48 + i * 54, 58, { index: i, bar: 1 })
+      );
+    }
+    for (i = 0; i < 12; i++) {
+      slots.push(
+        hangingSlot("bar-2-" + i, "hanging-lower", 48 + i * 54, 210, { index: i, bar: 2 })
+      );
+    }
+    for (i = 0; i < 8; i++) {
+      slots.push(
+        shelfSlot("shelf-" + i, "shelf-lower", 56 + i * 72, 400, { index: i, maxUnits: 1 })
+      );
+    }
+    for (i = 0; i < 4; i++) {
+      slots.push(pegSlot("wall-peg-" + i, 710, 58 + i * 78, { index: i }));
+    }
+    return {
+      id: "wallBay",
+      name: "3-Tier Wall Bay",
+      subtitle: "Two hanging bars, lower shelf, side pegs",
+      viewBox: "0 0 800 520",
+      frame: "wallBay",
+      slots: slots,
+    };
+  }
+
+  function nestingTable() {
+    var slots = [];
+    var i;
+    for (i = 0; i < 12; i++) {
+      var col = i % 6;
+      var row = Math.floor(i / 6);
+      slots.push(
+        shelfSlot("table-u-" + i, "table-upper", 90 + col * 90, 70 + row * 70, {
+          index: i,
+          w: 70,
+          h: 52,
+          maxUnits: 2,
+        })
+      );
+    }
+    for (i = 0; i < 12; i++) {
+      col = i % 6;
+      row = Math.floor(i / 6);
+      slots.push(
+        shelfSlot("table-l-" + i, "table-lower", 130 + col * 90, 300 + row * 70, {
+          index: i,
+          w: 70,
+          h: 52,
+          maxUnits: 2,
+        })
+      );
+    }
+    return {
+      id: "nestingTable",
+      name: "Nesting Table",
+      subtitle: "Two display levels for folded stacks",
+      viewBox: "0 0 800 520",
+      frame: "nestingTable",
+      slots: slots,
+    };
+  }
+
+  var TEMPLATES = [fourWay(), wallBay(), nestingTable()];
+  var byId = {};
+  TEMPLATES.forEach(function (f) {
+    f.capacity = f.slots.reduce(function (sum, s) {
+      return sum + s.maxUnits;
+    }, 0);
+    byId[f.id] = f;
+  });
+
+  return {
+    TEMPLATES: TEMPLATES,
+    getById: function (id) {
+      return byId[id] || TEMPLATES[0];
+    },
+    capacityOf: function (fixture) {
+      return fixture.capacity;
+    },
+  };
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a standalone **Atelier Planogram** workbench at `planogram.html` for building fashion fixture layouts.

- **Catalog & fixtures:** 15 mock apparel SKUs (jackets, tees, trousers, skirts, bags) with color, price, default facing, and SVG cutouts. Three templates: 4-Way Rack (40 units), 3-Tier Wall Bay (40 units), Nesting Table (48 units).
- **2D canvas:** Vector fixture frames with snap-point slots, drag-and-drop placement, facing visuals (front, side stack, folded stack + count badge, mannequin), and a live `units/capacity` counter.
- **Auto-Generate Planogram:** Color-flow (light→dark luminance), coordinate pairing (tops upper / bottoms lower), and cross-merchandising (matching bags on shelves and side pegs).
- **Export Visual Work Order:** Printable 2D planogram, SKU pick-list (SKU, image, name, facing count, units), and store merchandising notes.
- **Compliance audit tab:** Upload a mock floor photo beside the target planogram, Pass/Fail each placed SKU, and compute a compliance percentage.

## Test plan
- [x] `node planogram/js/algorithm.test.js`
- Open `planogram.html`, switch all three fixtures, drag SKUs onto slots, change facing/qty in the inspector.
- Toggle auto-generate rules and confirm color order, tops/bottoms split, and bags on pegs/shelf.
- Export work order and confirm print layout (planogram + BOM + notes).
- Audit tab: upload an image, mark Pass/Fail, confirm score.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dbf8cee-6d35-462b-8ca1-887ae240e3ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dbf8cee-6d35-462b-8ca1-887ae240e3ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

